### PR TITLE
Refactoring for the Dockerfiles

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -37,7 +37,8 @@ jobs:
         run: |
           docker build . -t minimal-compiler:${{ matrix.compiler }} -f Dockerfile-${{ matrix.compiler }}-minimal
           docker build . -t add-netcdf:${{ matrix.compiler }}       -f Dockerfile-add-netcdf --build-arg COMPILER=${{ matrix.compiler }}
-          docker build . -t rte-rrtmgp-ci:${{ matrix.compiler }}    -f Dockerfile-add-python --build-arg COMPILER=${{ matrix.compiler }}
+          docker build . -t add-python:${{ matrix.compiler }}       -f Dockerfile-add-python --build-arg COMPILER=${{ matrix.compiler }}
+          docker build . -t rte-rrtmgp-ci:${{ matrix.compiler }}    -f Dockerfile-finalize   --build-arg COMPILER=${{ matrix.compiler }}
           docker tag rte-rrtmgp-ci:${{ matrix.compiler }} earthsystemradiation/rte-rrtmgp-ci:${{ matrix.compiler }}
           docker push earthsystemradiation/rte-rrtmgp-ci:${{ matrix.compiler }}
 #          docker push ghcr.io/earth-system-radiation/rte-rrtmgp-ci:${{ matrix.compiler }}

--- a/Dockerfile-add-netcdf
+++ b/Dockerfile-add-netcdf
@@ -1,51 +1,34 @@
+#
+# Install NetCDF Fortran and its dependencies
+#
+
 ARG COMPILER
 FROM minimal-compiler:$COMPILER
-#
-# Install netCDF C and Fortran libraries and their dependencies
-#
-ENV NCHOME=/home/runner/netcdf-c NFHOME=/home/runner/netcdf-fortran
 
-# Install dependencies
-RUN apt clean
-RUN apt-get update && \
-    apt-get -y install git m4 && \
-    apt-get -y install libhdf5-dev libcurl4-gnutls-dev hdf5-helpers
+# Install the dependencies
+RUN apt-get update \
+ && apt-get --yes install \
+      --no-install-recommends \
+      libnetcdf-dev
 
-# Need to use bash because the Intel compilers require setting
-#   environment variables by sourcing a script
-SHELL [ "/usr/bin/bash", "-c"]
-
-# build netCDF C libraries
-# Would be best to put the environment variables in the RUN but haven't figured
-#   out how to do that with multiple variables
-ENV CPPFLAGS=-I/usr/include/hdf5/serial \
-    LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial/
-RUN source /opt/intel/oneapi/setvars.sh || true && \
-    mkdir -p /source && \
-    cd /source && \
-    rm -rf netcdf-c && \
-    git clone https://github.com/Unidata/netcdf-c.git --branch v4.7.4 && \
-    cd netcdf-c && \
-    ./configure --prefix=${NCHOME} && \
-    make -j && \
-    make install && \
-    make clean
-ENV CPPFLAGS="" LDFLAGS=""
-ENV LD_LIBRARY_PATH=${NCHOME}/lib
-#
-# netCDF Fortran libraries
-#
-ENV CPPFLAGS=-I${NCHOME}/include \
-    LDFLAGS=-L${NCHOME}/lib \
-    FCFLAGS=-fPIC
-RUN source /opt/intel/oneapi/setvars.sh || true && \
-    cd /source && \
-    rm -rf netcdf-fortran && \
-    git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.5.3 && \
-    cd netcdf-fortran && \
-    ./configure --prefix=${NFHOME} && \
-    make -j && \
-    make install && \
-    make clean
-ENV CPPFLAGS="" LDFLAGS=""
-ENV LD_LIBRARY_PATH=${NFHOME}/lib:${LD_LIBRARY_PATH}
+# Install NetCDF Fortran
+#   Reuse the argument
+ARG COMPILER
+#   The version must be compitible with NetCDF C installed above
+ARG NFVERSION=4.5.4
+RUN apt-get --yes install \
+      --no-install-recommends \
+      curl \
+  && curl https://downloads.unidata.ucar.edu/netcdf-fortran/$NFVERSION/netcdf-fortran-$NFVERSION.tar.gz | tar xz \
+  && cd netcdf-fortran-$NFVERSION \
+  && ./configure \
+       CC=$CC CFLAGS='-O2' \
+       FC=$COMPILER FCFLAGS='-O2 -fPIC' \
+       --prefix=/opt/netcdf-fortran \
+       --disable-static \
+  && make -j \
+  && make install \
+  && cd .. \
+  && rm -rf netcdf-fortran-$NFVERSION \
+  && echo '/opt/netcdf-fortran/lib' > /etc/ld.so.conf.d/libnetcdff.conf \
+  && ldconfig

--- a/Dockerfile-add-python
+++ b/Dockerfile-add-python
@@ -1,9 +1,30 @@
-ARG COMPILER
-FROM add-netcdf:$COMPILER
 #
 # Install Python3 and a small set of packages
 #
-RUN apt-get update && \
-    apt-get -y install python3 python3-pip && \
-    pip3 install urllib3 netcdf4 xarray dask scipy matplotlib seaborn colorcet && \
-    apt install python-is-python3
+
+ARG COMPILER
+FROM add-netcdf:$COMPILER
+
+# Install Python
+RUN apt-get update \
+ && apt-get --yes install \
+      --no-install-recommends \
+      python-is-python3 \
+      python3 \
+      python3-pip
+
+# Install essential packages
+#   we install netCDF4 instead of xarray[io] to omit unnecessary packages
+RUN pip3 install \
+      dask[array] \
+      netCDF4 \
+      numpy \
+      xarray
+
+# Install packages for the validation plot generation
+#   we install scipy instead of xarray[accel] to omit unnecessary packages
+RUN pip3 install \
+      colorcet \
+      matplotlib \
+      scipy \
+      seaborn

--- a/Dockerfile-finalize
+++ b/Dockerfile-finalize
@@ -1,0 +1,12 @@
+#
+# Finalize CI containers
+#
+
+ARG COMPILER
+FROM add-python:$COMPILER
+
+# Install additional tools
+RUN apt-get update \
+ && apt-get --yes install \
+      --no-install-recommends \
+      zstd

--- a/Dockerfile-ifort-minimal
+++ b/Dockerfile-ifort-minimal
@@ -1,37 +1,4 @@
-FROM ubuntu:22.04
-
-# Extend and update the package registry
-RUN apt-get update \
- && apt-get --yes install \
-      --no-install-recommends \
-      ca-certificates \
-      curl \
-      gpg \
- && curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
-      | gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg \
- && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list \
- && apt-get update
-
-# Install compilers and build tools
-RUN apt-get --yes install \
-      --no-install-recommends \
-      binutils \
-      g++ \
-      gcc \
-      intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
-      intel-oneapi-compiler-fortran \
-      libc-dev \
-      make
-
-# Initialize Intel compiler for login shells
-RUN echo ". /opt/intel/oneapi/setvars.sh" >> /etc/profile.d/oneapi.sh
+FROM intel/oneapi-hpckit:2023.0.0-devel-ubuntu22.04
 
 # Set default compiler executables
 ENV FC=ifort CC=icc
-
-# Enable Intel compiler for the Dockerfile instructions
-SHELL ["/bin/bash", "-lc"]
-
-# Enable Intel compiler for the CLI commands and interactive mode
-ENTRYPOINT ["/bin/bash", "-lc", "\"$@\"", "--"]
-CMD ["/bin/bash"]

--- a/Dockerfile-ifort-minimal
+++ b/Dockerfile-ifort-minimal
@@ -1,28 +1,37 @@
-# Build stage
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
-#
-# System tools used by OneAPI. Adapted from OneAPI os-tools-ubuntu
-#
-RUN apt-get update && \
-    apt-get install --yes wget \
-    libc6-dev libc6 libc-bin \
-    make cmake \
-    ca-certificates \
-    gnupg
+# Extend and update the package registry
+RUN apt-get update \
+ && apt-get --yes install \
+      --no-install-recommends \
+      ca-certificates \
+      curl \
+      gpg \
+ && curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
+      | gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list \
+ && apt-get update
 
-# configure the repository
-RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB && \
-    apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB && \
-    echo "deb https://apt.repos.intel.com/oneapi all main" >> /etc/apt/sources.list # /etc/apt/sources.list.d/oneAPI.list
+# Install compilers and build tools
+RUN apt-get --yes install \
+      --no-install-recommends \
+      binutils \
+      g++ \
+      gcc \
+      intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
+      intel-oneapi-compiler-fortran \
+      libc-dev \
+      make
 
-RUN apt-get update && \
-    apt-get install --yes intel-hpckit-getting-started intel-oneapi-clck && \
-    apt-get install --yes intel-oneapi-common-licensing intel-oneapi-common-vars && \
-    apt-get install --yes intel-oneapi-dev-utilities  intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic && \
-    apt-get install --yes intel-oneapi-compiler-fortran intel-oneapi-inspector intel-oneapi-itac
+# Initialize Intel compiler for login shells
+RUN echo ". /opt/intel/oneapi/setvars.sh" >> /etc/profile.d/oneapi.sh
 
-RUN apt-get install curl
-RUN apt-get install zstd || true
+# Set default compiler executables
+ENV FC=ifort CC=icc
 
-ENV FC=ifort CC=icx
+# Enable Intel compiler for the Dockerfile instructions
+SHELL ["/bin/bash", "-lc"]
+
+# Enable Intel compiler for the CLI commands and interactive mode
+ENTRYPOINT ["/bin/bash", "-lc", "\"$@\"", "--"]
+CMD ["/bin/bash"]

--- a/Dockerfile-nvfortran-minimal
+++ b/Dockerfile-nvfortran-minimal
@@ -4,12 +4,5 @@
 #
 FROM nvcr.io/nvidia/nvhpc:22.9-devel-cuda11.7-ubuntu22.04
 
-# Initialize Nvidia compiler for login shells
-RUN echo 'module load nvhpc-nompi' >> /etc/profile.d/nvhpc.sh
-
-# Enable Nvidia compiler for the Dockerfile instructions
-SHELL ["/bin/bash", "-lc"]
-
-# Enable Nvidia compiler for the CLI commands and interactive mode
-ENTRYPOINT ["/bin/bash", "-lc", "\"$@\"", "--"]
-CMD ["/bin/bash"]
+# Set default compiler executables
+ENV FC=nvfortran CC=nvc

--- a/Dockerfile-nvfortran-minimal
+++ b/Dockerfile-nvfortran-minimal
@@ -4,7 +4,12 @@
 #
 FROM nvcr.io/nvidia/nvhpc:22.9-devel-cuda11.7-ubuntu22.04
 
-RUN apt-get install zstd || true
+# Initialize Nvidia compiler for login shells
+RUN echo 'module load nvhpc-nompi' >> /etc/profile.d/nvhpc.sh
 
-ENV FC=nvfortran CC=nvc NVCOMPILERS=/opt/nvidia/hpc_sdk
-ENV PATH=${NVCOMPILERS}/Linux_x86_64/22.9/compilers/bin:${PATH}
+# Enable Nvidia compiler for the Dockerfile instructions
+SHELL ["/bin/bash", "-lc"]
+
+# Enable Nvidia compiler for the CLI commands and interactive mode
+ENTRYPOINT ["/bin/bash", "-lc", "\"$@\"", "--"]
+CMD ["/bin/bash"]

--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,8 @@ For the `ifort` image:
 ```
 docker build . -t minimal-compiler:ifort -f Dockerfile-ifort-minimal
 docker build . -t add-netcdf:ifort -f Dockerfile-add-netcdf --build-arg COMPILER=ifort
-docker build . -t rte-rrtmgp-ci:ifort -f Dockerfile-add-python --build-arg COMPILER=ifort
+docker build . -t add-python:ifort -f Dockerfile-add-python --build-arg COMPILER=ifort
+docker build . -t rte-rrtmgp-ci:ifort -f Dockerfile-finalize --build-arg COMPILER=ifort
 docker tag rte-rrtmgp-ci:ifort earthsystemradiation/rte-rrtmgp-ci:ifort
 docker push earthsystemradiation/rte-rrtmgp-ci:ifort
 ```
@@ -29,7 +30,8 @@ docker build . -t minimal-compiler:nvfortran -f Dockerfile-nvfortran-minimal # a
 docker pull nvcr.io/nvidia/nvhpc:21.1-devel-cuda11.2-ubuntu20.04 # worked fine
 docker build . -t minimal-compiler:nvfortran -f Dockerfile-nvfortran-minimal
 docker build . -t add-netcdf:nvfortran -f Dockerfile-add-netcdf --build-arg COMPILER=nvfortran
-docker build . -t rte-rrtmgp-ci:nvfortran -f Dockerfile-add-python --build-arg COMPILER=nvfortran
+docker build . -t add-python:nvfortran -f Dockerfile-add-python --build-arg COMPILER=nvfortran
+docker build . -t rte-rrtmgp-ci:nvfortran -f Dockerfile-finalize --build-arg COMPILER=nvfortran
 docker tag rte-rrtmgp-ci:nvfortran earthsystemradiation/rte-rrtmgp-ci:nvfortran
 docker push earthsystemradiation/rte-rrtmgp-ci:nvfortran
 ```
@@ -38,8 +40,9 @@ To elaborate on the common steps in these processes:
 
 1. **Build local starter image**: using direction from a compiler-dependent Dockerfile (`-f Dockerfile-*-minimal`) in the current working directory (`build .`), build an image with the OS and compiler requirements, then tag it as `-t minimal-compiler:$COMPILER` (`$COMPILER` either `ifort` or `nvfortran`).
 2. **Build local netCDF image**: using direction from `Dockerfile-add-netcdf` in the current working directory (`build .`), build an image on top of the starter, then tag it as `-t add-netcdf:$COMPILER` (`$COMPILER` either `ifort` or `nvfortran`).
-3. **Build Python image**: using direction from `Dockerfile-add-python` in the current working directory (`build .`), build an image that will be used in RTE+RRTMGP Continuous Integration (CI), then tag it as `-t rte-rrtmgp-ci:$COMPILER` (`$COMPILER` either `ifort` or `nvfortran`).
-4. **Tag for and push to public repository**: tag the local images from Step 3 with their counterparts in the `earthsystemradion` DockerHub repository, again separating by compiler, then push to the repository
+3. **Build Python image**: using direction from `Dockerfile-add-python` in the current working directory (`build .`), build an image on top of the netCDF image, then tag it as `-t add-python:$COMPILER` (`$COMPILER` either `ifort` or `nvfortran`).
+4. **Build final CI image**: using direction from `Dockerfile-finalize` in the current working directory (`build .`), build an image on top of the Python image that will be used in RTE+RRTMGP Continuous Integration (CI), then tag it as `-t rte-rrtmgp-ci:$COMPILER` (`$COMPILER` either `ifort` or `nvfortran`).
+5. **Tag for and push to public repository**: tag the local images from Step 3 with their counterparts in the `earthsystemradion` DockerHub repository, again separating by compiler, then push to the repository
 
 Local builds can be bypassed by replacing local image names in the build with the DockerHub repository names, e.g.:
 
@@ -63,9 +66,11 @@ The previous command will build all images. For specific images, users can provi
 2. `min-nvfortran`
 3. `nc-ifort`
 4. `nc-nvfortran`
-5. `ci-ifort`
-6. `ci-nvfortran`
+5. `py-ifort`
+6. `py-nvfortran`
+7. `ci-ifort`
+8. `ci-nvfortran`
 
-Note that images 3-6 depend on previous services, but Docker Compose only has a `depends_on` option for [running the services](https://stackoverflow.com/a/37945466) (i.e., running the container) so one either has to build the images at the beginning of the chain or already have them in their local image repository.
+Note that images 3-8 depend on previous services, but Docker Compose only has a `depends_on` option for [running the services](https://stackoverflow.com/a/37945466) (i.e., running the container) so one either has to build the images at the beginning of the chain or already have them in their local image repository.
 
 Again, `docker-compose` can be used to run services as well, but the service stack will need more additions before anything of substance can be performed.

--- a/rte-rrtmgp-ci.yml
+++ b/rte-rrtmgp-ci.yml
@@ -36,13 +36,31 @@ services:
       dockerfile: Dockerfile-add-netcdf
       args:
         - COMPILER=nvfortran
-    image: minimal-compiler:nvfortran
+    image: add-netcdf:nvfortran
     container_name: nc-nvfortran
+
+  py-ifort:
+    build:
+      context: ./
+      dockerfile: Dockerfile-add-python
+      args:
+        - COMPILER=ifort
+    image: add-python:ifort
+    container_name: py-ifort
+
+  py-nvfortran:
+    build:
+      context: ./
+      dockerfile: Dockerfile-add-python
+      args:
+        - COMPILER=nvfortran
+    image: add-python:nvfortran
+    container_name: py-nvfortran
 
   ci-ifort:
     build:
       context: ./
-      dockerfile: Dockerfile-add-python
+      dockerfile: Dockerfile-finalize
       args:
         - COMPILER=ifort
     image: earthsystemradiation/rte-rrtmgp-ci:ifort
@@ -51,7 +69,7 @@ services:
   ci-nvfortran:
     build:
       context: ./
-      dockerfile: Dockerfile-add-python
+      dockerfile: Dockerfile-finalize
       args:
         - COMPILER=nvfortran
     image: earthsystemradiation/rte-rrtmgp-ci:nvfortran


### PR DESCRIPTION
1. The containers explicitly use the same OS: `Ubuntu 22.04`.
2. Intel container does not require the CI jobs to source `/opt/intel/oneapi/setvars.sh` explicitly before using the compilers.
3. Intel container now uses the official [`intel/oneapi-hpckit`](https://hub.docker.com/r/intel/oneapi-hpckit) image.
4. All GitHub-Actions-specific packages are now installed with `Dockerfile-finalize` (currently only `zstd` for the caching). This also fixes the `nvfortran` container, because `RUN apt-get install zstd || true` has no effect if not preceded with `apt-get update`.
5. Uses `libnetcdf-dev` instead of building NetCDF C from sources. Also, eliminates the need for setting `LD_LIBRARY_PATH`.
6. Removes redundant environment modifications.