### PR TITLE
Reduce size of the Intel container image

### DIFF
--- a/Dockerfile-add-netcdf
+++ b/Dockerfile-add-netcdf
@@ -7,19 +7,17 @@ FROM minimal-compiler:$COMPILER
 
 # Install the dependencies
 RUN apt-get update \
- && apt-get --yes install \
-      --no-install-recommends \
-      libnetcdf-dev
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
+      curl \
+      libnetcdf-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install NetCDF Fortran
 #   Reuse the argument
 ARG COMPILER
 #   The version must be compitible with NetCDF C installed above
 ARG NFVERSION=4.5.4
-RUN apt-get --yes install \
-      --no-install-recommends \
-      curl \
-  && curl https://downloads.unidata.ucar.edu/netcdf-fortran/$NFVERSION/netcdf-fortran-$NFVERSION.tar.gz | tar xz \
+RUN curl https://downloads.unidata.ucar.edu/netcdf-fortran/$NFVERSION/netcdf-fortran-$NFVERSION.tar.gz | tar xz \
   && cd netcdf-fortran-$NFVERSION \
   && ./configure \
        CC=$CC CFLAGS='-O2' \

--- a/Dockerfile-add-netcdf
+++ b/Dockerfile-add-netcdf
@@ -19,11 +19,12 @@ ARG COMPILER
 ARG NFVERSION=4.5.4
 RUN curl https://downloads.unidata.ucar.edu/netcdf-fortran/$NFVERSION/netcdf-fortran-$NFVERSION.tar.gz | tar xz \
   && cd netcdf-fortran-$NFVERSION \
-  && ./configure \
-       CC=$CC CFLAGS='-O2' \
-       FC=$COMPILER FCFLAGS='-O2 -fPIC' \
-       --prefix=/opt/netcdf-fortran \
-       --disable-static \
+  && { ./configure \
+         CC=$CC CFLAGS='-O2' \
+         FC=$COMPILER FCFLAGS='-O2 -fPIC' \
+         --prefix=/opt/netcdf-fortran \
+         --disable-static || \
+       { cat ./config.log; exit 1; } } \
   && make -j \
   && make install \
   && cd .. \

--- a/Dockerfile-add-netcdf
+++ b/Dockerfile-add-netcdf
@@ -13,15 +13,13 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Install NetCDF Fortran
-#   Reuse the argument
-ARG COMPILER
 #   The version must be compitible with NetCDF C installed above
 ARG NFVERSION=4.5.4
 RUN curl https://downloads.unidata.ucar.edu/netcdf-fortran/$NFVERSION/netcdf-fortran-$NFVERSION.tar.gz | tar xz \
   && cd netcdf-fortran-$NFVERSION \
   && { ./configure \
-         CC=$CC CFLAGS='-O2' \
-         FC=$COMPILER FCFLAGS='-O2 -fPIC' \
+         CFLAGS='-O2' \
+         FCFLAGS='-O2 -fPIC' \
          --prefix=/opt/netcdf-fortran \
          --disable-static || \
        { cat ./config.log; exit 1; } } \

--- a/Dockerfile-add-python
+++ b/Dockerfile-add-python
@@ -7,11 +7,11 @@ FROM add-netcdf:$COMPILER
 
 # Install Python
 RUN apt-get update \
- && apt-get --yes install \
-      --no-install-recommends \
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
       python-is-python3 \
       python3 \
-      python3-pip
+      python3-pip \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install essential packages
 #   we install netCDF4 instead of xarray[io] to omit unnecessary packages

--- a/Dockerfile-finalize
+++ b/Dockerfile-finalize
@@ -7,6 +7,6 @@ FROM add-python:$COMPILER
 
 # Install additional tools
 RUN apt-get update \
- && apt-get --yes install \
-      --no-install-recommends \
-      zstd
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
+      zstd \
+ && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile-ifort-minimal
+++ b/Dockerfile-ifort-minimal
@@ -1,4 +1,29 @@
-FROM intel/oneapi-hpckit:2023.2-devel-ubuntu22.04
+FROM ubuntu:22.04
+
+ARG ONEAPI_VERSION='2023.2.1'
+
+# Extend and update the package registry
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
+      ca-certificates \
+      curl \
+      gpg \
+      binutils \
+      g++ \
+      gcc \
+      libc-dev \
+      make \
+ && curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
+      | gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
+      intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-${ONEAPI_VERSION} \
+      intel-oneapi-compiler-fortran-${ONEAPI_VERSION} \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/bin/intel64:/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}"
 
 # Set default compiler executables
 ENV FC=ifort CC=icc


### PR DESCRIPTION
It looks like the official Intel `oneapi-hpckit` image became too big to meet [the limitations for GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). This is relevant for the jobs that build the images, as well as for the CI jobs of the [`rte-rrtmgp`](https://github.com/earth-system-radiation/rte-rrtmgp) project: all fail at some point with the `no space left on device` error. Unfortunately, switching to another official image, `oneapi-basekit` (plus `apt-get install intel-oneapi-compiler-fortran`), doesn't help. Therefore, this PR switches to a custom image similar to the one we had before #9. The uncompressed image is about 5GB now.

Additionally, I tried to make other layers of the resulting images a bit smaller as well. But those are probably peanuts though.