### PR TITLE
Add missing LD_LIBRARY_PATH entry in the Intel container

### DIFF
--- a/Dockerfile-ifort-minimal
+++ b/Dockerfile-ifort-minimal
@@ -23,7 +23,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/bin/intel64:/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/lib:/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}"
 
 # Set default compiler executables
 ENV FC=ifort CC=icc


### PR DESCRIPTION
This is a fixup for #15, which adds a missing `LD_LIBRARY_PATH` entry pointing to the location of the `libomptarget.so`, which is required for the [`ifx-accel` CI jobs](https://github.com/earth-system-radiation/rte-rrtmgp/blob/c45e7bc1afe3900f2b3f317b125c8b3b857d5a9e/.github/workflows/containerized-ci.yml#L30-L33).