### PR TITLE
Reduce size of the Nvidia container image

### DIFF
--- a/Dockerfile-nvfortran-minimal
+++ b/Dockerfile-nvfortran-minimal
@@ -16,7 +16,10 @@ RUN apt-get update \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
       nvhpc-${NVHPC_VERSION_MAJOR}-${NVHPC_VERSION_MINOR} \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && for dir in comm_libs examples math_libs profilers; do \
+      rm -rf "/opt/nvidia/hpc_sdk/Linux_x86_64/${NVHPC_VERSION_MAJOR}.${NVHPC_VERSION_MINOR}/${dir}"; \
+    done
 
 ENV PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/${NVHPC_VERSION_MAJOR}.${NVHPC_VERSION_MINOR}/compilers/bin:${PATH}"
 

--- a/Dockerfile-nvfortran-minimal
+++ b/Dockerfile-nvfortran-minimal
@@ -1,8 +1,24 @@
-#
-# Most current mix of compiler and single CUDA version available from
-#   https://ngc.nvidia.com/catalog/containers/nvidia:nvhpc/tags
-#
-FROM nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu22.04
+FROM ubuntu:22.04
+
+ARG NVHPC_VERSION_MAJOR='23'
+ARG NVHPC_VERSION_MINOR='7'
+
+# Extend and update the package registry
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
+      ca-certificates \
+      curl \
+      gpg \
+      make \
+ && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK \
+      | gpg --dearmor > /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /" > /etc/apt/sources.list.d/nvhpc.list \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
+      nvhpc-${NVHPC_VERSION_MAJOR}-${NVHPC_VERSION_MINOR} \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/${NVHPC_VERSION_MAJOR}.${NVHPC_VERSION_MINOR}/compilers/bin:${PATH}"
 
 # Set default compiler executables
 ENV FC=nvfortran CC=nvc


### PR DESCRIPTION
I have stumbled upon the same `no space left on device` problem as in #15 but with the Nvidia image. This PR switches from the official image to a custom one in a similar way.

Unfortunately, Nvidia does not provide the same level of granularity as Intel does: either with a tarball or via the package managers, we cannot install only the required components of the SDK. Therefore, the size of the image cannot be reduced in a clean way. What I did in this PR was the "manual" removal of the components that we don't need (see 5dd0085). A bit hacky but seems to work. Note, however, that 5dd0085 can be dropped for now. It would work but for reasons that are not clear to me because the size of the image is more or less the same as the size of the official one. My assumption is that this custom image requires less temporary disk space when run by Docker (for whatever reason). I would not rely on this behaviour though: if we keep the commit, we are guaranteed to meet the disk space limit as the size of the compressed/uncompressed image becomes ~1.4GB/3.9GB.