### PR TITLE
Upgrade to NVHPC 24.1

### DIFF
--- a/Dockerfile-nvhpc-minimal
+++ b/Dockerfile-nvhpc-minimal
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
-ARG NVHPC_VERSION_MAJOR='23'
-ARG NVHPC_VERSION_MINOR='9'
+ARG NVHPC_VERSION_MAJOR='24'
+ARG NVHPC_VERSION_MINOR='1'
 
 # Extend and update the package registry
 RUN apt-get update \


### PR DESCRIPTION
This keeps the `develop` and the `main` branches of the [rte-rrtmgp repo](https://github.com/earth-system-radiation/rte-rrtmgp) green. See [here](https://github.com/skosukhin/rte-rrtmgp/actions/runs/7722664449) and [here](https://github.com/skosukhin/rte-rrtmgp/actions/runs/7722852650), respectively.